### PR TITLE
Issue#8: added two buttons for organizations without datasets: 

### DIFF
--- a/ckanext/datamx_theme/templates/organization/read.html
+++ b/ckanext/datamx_theme/templates/organization/read.html
@@ -34,17 +34,30 @@
       </div>
     </div>
     {{ h.snippet('snippets/package_list.html', packages=c.page.items) }}
+  {% else %}
+    <div class="organization-actions">
+      <div class="sort-datasets">
+      </div>
+      <div class="pull-right">
+        {% if h.check_access("organization_update", {"id": organization.id}) %}
+        {% link_for _("Manage"), controller="organization", action="edit", id=organization.name, class_="btn", icon="wrench" %}
+        {% endif %}
+        {% if h.check_access("package_create", { "owner_org": organization.id }) %}
+        {% link_for _("Add Dataset"), controller="package", action="new", group=organization.id, class_="btn btn-primary", icon="plus-sign-alt" %}
+        {% endif %}
+      </div>
+    </div>
   {% endif %}
 {% endblock %}
 
 {% block page_pagination %}
-  {{ c.page.pager(q=c.q) }}
+{{ c.page.pager(q=c.q) }}
 {% endblock %}
 
 {% block apps_list %}
   <h3>Apps C&iacute;vicas</h3>
   <p>Descubre qui&eacute;nes usan y c&oacute;mo se usan los datos abiertos<br />en M&eacute;xico para mejorar el pa&iacute;s.</p>
-  {% resource "datamx_theme/datamx_theme_load_apps.js" %}
+{% resource "datamx_theme/datamx_theme_load_apps.js" %}
   <div
     data-module="datamx_theme_load_apps"
     data-module-organization="{{ organization.name }}" >


### PR DESCRIPTION
manage organization & add dataset. The buttons were missing and it's better if you could go directly from the organization profile.
